### PR TITLE
Use a single static parser for both performance and avoiding leaks

### DIFF
--- a/benchmark/leak.rb
+++ b/benchmark/leak.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
+require 'fast_jsonparser'
+
+Thread.abort_on_exception = true
+
+3.times do
+  Thread.new do
+    loop do
+      begin
+        FastJsonparser.parse('{"foo": "bar"')
+      rescue
+      end
+    end
+  end
+end
+
+loop do
+  sleep 1
+  p `ps -o rss -p #{$$}`.chomp.split("\n").last.to_i
+end

--- a/ext/fast_jsonparser/fast_jsonparser.cpp
+++ b/ext/fast_jsonparser/fast_jsonparser.cpp
@@ -5,6 +5,7 @@
 VALUE rb_eFastJsonparserUnknownError, rb_eFastJsonparserParseError;
 
 using namespace simdjson;
+static dom::parser parser;
 
 // Convert tape to Ruby's Object
 static VALUE make_ruby_object(dom::element element, bool symbolize_keys)
@@ -71,7 +72,6 @@ static VALUE rb_fast_jsonparser_parse(VALUE self, VALUE arg, VALUE symbolize_key
 {
     Check_Type(arg, T_STRING);
 
-    dom::parser parser;
     auto [doc, error] = parser.parse(RSTRING_PTR(arg), RSTRING_LEN(arg));
     if (error != SUCCESS)
     {
@@ -84,7 +84,6 @@ static VALUE rb_fast_jsonparser_load(VALUE self, VALUE arg, VALUE symbolize_keys
 {
     Check_Type(arg, T_STRING);
 
-    dom::parser parser;
     auto [doc, error] = parser.load(RSTRING_PTR(arg));
     if (error != SUCCESS)
     {
@@ -98,9 +97,7 @@ static VALUE rb_fast_jsonparser_load_many(VALUE self, VALUE arg, VALUE symbolize
     Check_Type(arg, T_STRING);
     Check_Type(batch_size, T_FIXNUM);
 
-    try
-    {
-        dom::parser parser;
+    try {
         auto [docs, error] = parser.load_many(RSTRING_PTR(arg), FIX2INT(batch_size));
         if (error != SUCCESS)
         {


### PR DESCRIPTION
@XrXr pointed out to me that `rb_raise` isn't quite safe in C++. Long story short `rb_raise` bypass the C++ destructors which can lead to various leaks etc.

Notably `simdjson::dom::parser` has a destructor it uses to deallocate the memory it uses. I attached the `leak.rb` script, if you run it against maser you'll see memory usage go through the root very quickly.

The good new is that `simdjson::dom::parser` is designed to be re-used. When you call it again it re-use the memory it previously allocated, so by instantiating a single parser once, and then using only that one, we avoid leaks.

The added benefit is that it should be slightly  more performant as `parse`, `load`, and `load_many` no longer need to build the parser.

Ref: https://github.com/simdjson/simdjson/blob/master/doc/performance.md#reusing-the-parser-for-maximum-efficiency
Also note that this strategy can work because simdjson is thread safe for now (https://github.com/simdjson/simdjson/issues/681), if that change we might need a different strategy.


