### PR TITLE
Handle concurrent use of the parser

### DIFF
--- a/lib/fast_jsonparser.rb
+++ b/lib/fast_jsonparser.rb
@@ -12,15 +12,15 @@ module FastJsonparser
 
   class << self
     def parse(source, symbolize_keys: true)
-      _parse(source, symbolize_keys)
+      parser._parse(source, symbolize_keys)
     end
 
     def load(source, symbolize_keys: true)
-      _load(source, symbolize_keys)
+      parser._load(source, symbolize_keys)
     end
 
     def load_many(source, symbolize_keys: true, batch_size: DEFAULT_BATCH_SIZE, &block)
-      _load_many(source, symbolize_keys, batch_size, &block)
+      Native.new._load_many(source, symbolize_keys, batch_size, &block)
     rescue UnknownError => error
       case error.message
       when "This parser can't support a document that big"
@@ -30,7 +30,17 @@ module FastJsonparser
       end
     end
 
-    require "fast_jsonparser/fast_jsonparser" # loads cpp extension
-    private :_parse, :_load, :_load_many
+    private
+
+    def parser
+      @parser ||= Native.new
+    end
   end
+
+  class Native
+  end
+
+  require "fast_jsonparser/fast_jsonparser" # loads cpp extension
+
+  private_constant :Native
 end

--- a/test/fast_jsonparser_test.rb
+++ b/test/fast_jsonparser_test.rb
@@ -70,85 +70,11 @@ class FastJsonparserTest < Minitest::Test
     end
   end
 
-  def test_compat_forward_slash_escape
-    assert_compat('"\/"', "/")
-  end
-
-  def test_compat_backward_slash_escape
-    assert_compat('"\\\\"', '\\')
-  end
-
-  def test_compat_illegal_escape
-    refute_compat('["Illegal backslash escape: \x15"]', ["Illegal backslash escape: x15"], :raises)
-  end
-
-  def test_compat_utf8
-    assert_compat('"École"', "École")
-  end
-
-  def test_compat_NaN_and_Infinity
-    assert_compat('[NaN]', :raises)
-    assert_compat('[Infinity]', :raises)
-    assert_compat('[-Infinity]', :raises)
-  end
-
-  def test_compat_hex_numbers
-    assert_compat('[0x42]', :raises)
-  end
-
-  def test_compat_weird_keys
-    assert_compat('{[1]:2}', :raises)
-    assert_compat('{{1:2}:2}', :raises)
-    assert_compat('{null:2}', :raises)
-  end
-
-  def test_compat_trailing_commas
-    assert_compat('{1:2,}', :raises)
-    assert_compat('{,,,,}', :raises)
-    assert_compat('[1,]', :raises)
-    assert_compat('[,,,,]', :raises)
-  end
-
-  def test_compat_trailing_comments
-    assert_compat('{} // comment', :raises)
-    refute_compat('{} /* comment */', {}, :raises)
-    assert_compat('{1:/*comment*/2}', :raises)
-    refute_compat('{"a":/*comment*/"b"}', { "a" => "b" }, :raises)
-  end
-
-  def test_compat_float_precision
-    assert_compat '1.3553e142', 1.3553e142
-    assert_compat '1.3553E142', 1.3553E142
-  end
-
-  def test_compat_big_floats
-    assert_compat '100000000000000000000000000000000000000000.0', 100000000000000000000000000000000000000000.0
-  end
-
-  def test_compat_big_integers
-    assert_compat '18446744073709551615', 18446744073709551615
-    refute_compat '18446744073709551616', 18446744073709551616, :raises
-
-    assert_compat '-9223372036854775808', -9223372036854775808
-    refute_compat '-9223372036854775809', -9223372036854775809, :raises
-  end
-
-  private
-
-  def assert_compat(source, expected)
-    assert_equal expected, parse(JSON, source), "This test is invalid"
-    assert_equal expected, parse(FastJsonparser, source), "#{source.inspect} is not parsed the same by JSON and FastJsonparser"
-  end
-
-  def refute_compat(source, expected, got)
-    refute_equal expected, got
-    assert_equal expected, parse(JSON, source)
-    assert_equal got, parse(FastJsonparser, source)
-  end
-
-  def parse(parser, source)
-    parser.parse(source)
-  rescue => error
-    :raises
+  def test_nested_usage
+    FastJsonparser.load_many('./benchmark/nginx_json_logs.json') do
+      test_json_load_from_file_is_working
+      test_json_parse_is_working
+      break
+    end
   end
 end


### PR DESCRIPTION
Contrary to what I said in #12, dom::parser is no longer thread safe.

For `load` and `parse` it isn't a problem as Ruby's GVL is not released so no concurrency is possible.

However `load_many` yield back to Ruby code so it allow for concurrent use of the parser, and that cause various parsing errors.

As a solution I wrapped the parser inside a Ruby object so that multiple can exist, and the Ruby GC will handle their lifecycle.

Since `parse` and `load` don't allow for concurrency they cause use a single parser, however `load_many` will create a new one every time.

This refactor also open the door to releasing the GVL during parsing. It could make sense for `load` at least as users likely expect the GVL to be released on IOs.