### PR TITLE
Updated Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 PATH
   remote: .
   specs:
-    fast_jsonparser (0.4.0)
+    fast_jsonparser (0.5.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    minitest (5.14.1)
-    oj (3.10.6)
-    rake (13.0.1)
-    rake-compiler (1.1.0)
+    minitest (5.14.4)
+    oj (3.11.7)
+    rake (13.0.3)
+    rake-compiler (1.1.1)
       rake
     yajl-ruby (1.4.1)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   bundler (~> 2.0)
@@ -26,4 +26,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   2.0.1
+   2.2.3


### PR DESCRIPTION
**bundle install** command was failing because of Gemfile.lock having unsupported dependency versions for ruby-3.0.
