### PR TITLE
Fix performance on Ruby 3.0

### DIFF
--- a/ext/fast_jsonparser/extconf.rb
+++ b/ext/fast_jsonparser/extconf.rb
@@ -1,5 +1,5 @@
 require 'mkmf'
-$CXXFLAGS += ' -std=c++1z -Wno-register '
+$CXXFLAGS += ' $(optflags) $(debugflags) -std=c++1z -Wno-register '
 
 
 create_makefile 'fast_jsonparser/fast_jsonparser'


### PR DESCRIPTION
The Makefile generated by extconf.rb has changed in Ruby 3.0.
Therefore, when using Ruby 3.0, the optimization flags are not set properly and it reduced the performance.

This patch will set optimization flags in compiling properly.

- Here is Ruby 2.7 Makefile result:

```
CXXFLAGS = $(CCDLFLAGS) -g -O2 -std=c++1z -Wno-register  $(ARCH_FLAG)
```

- Here is Ruby 3.0 Makefile result:

```
CXXFLAGS = $(CCDLFLAGS)  -std=c++1z -Wno-register  $(ARCH_FLAG)
```

This PR will fix https://github.com/anilmaurya/fast_jsonparser/issues/20 issue.