### PR TITLE
fix windows compatibility

### DIFF
--- a/ext/fast_jsonparser/fast_jsonparser.cpp
+++ b/ext/fast_jsonparser/fast_jsonparser.cpp
@@ -71,11 +71,19 @@ static VALUE make_ruby_object(dom::element element, bool symbolize_keys)
     }
     case dom::element_type::INT64:
     {
-        return LONG2NUM(element.get<int64_t>());
+        if (SIZEOF_LONG == 4) {
+          return LL2NUM(element.get<int64_t>());
+        } else {
+          return LONG2NUM(element.get<int64_t>());
+        }
     }
     case dom::element_type::UINT64:
     {
-        return ULONG2NUM(element.get<uint64_t>());
+        if (SIZEOF_LONG_LONG == 4) {
+            return ULL2NUM(element.get<uint64_t>());
+        } else {
+            return ULONG2NUM(element.get<uint64_t>());
+        }
     }
     case dom::element_type::DOUBLE:
     {


### PR DESCRIPTION
the size of long on Windows platforms is 32 bits (even with 64 bit binaries). So the assumed sizeof(int64_t) != sizeof(long) isn't true. This leads to the corruption of > 32 bit numbers on such platforms due to the overflow.

fixes https://github.com/anilmaurya/fast_jsonparser/issues/17

ad. there's probably a much cleaner way to do it :)